### PR TITLE
Fix local run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ The ideas/purposes behind every shiny app in this repository are:
 
 ## Using apps locally
 
-There is a script `run_app.R` which contanins a helper function to
+There is a script `run_app.R` which contains a helper function to
 download the repo in a temporal folder and then you can run the apps
 
 To load that function:
 
 ``` r
-source("https://raw.githubusercontent.com/jbkunst/shiny-apps-edu/master/run_app.R")
+source("https://raw.githubusercontent.com/jbkunst/shiny-apps-educational/master/run_app.R")
 ```
 
 Then you can use it giving the folder name, for example:

--- a/readme.Rmd
+++ b/readme.Rmd
@@ -31,12 +31,12 @@ By themselves, the apps are just an app.
 
 ## Using apps locally
 
-There is a script `run_app.R` which contanins a helper function to download the repo in a temporal folder and then you can run the apps
+There is a script `run_app.R` which contains a helper function to download the repo in a temporal folder and then you can run the apps
 
 To load that function:
 
 ```{r, echo=TRUE, eval=FALSE}
-source("https://raw.githubusercontent.com/jbkunst/shiny-apps-edu/master/run_app.R")
+source("https://raw.githubusercontent.com/jbkunst/shiny-apps-educational/master/run_app.R")
 ```
 
 Then you can use it giving the folder name, for example:

--- a/run_app.R
+++ b/run_app.R
@@ -1,6 +1,6 @@
 run_app <- function(app = "kmeans"){
   
-  url <- "https://github.com/jbkunst/shiny-apps-edu/archive/refs/heads/master.zip"
+  url <- "https://github.com/jbkunst/shiny-apps-educational/archive/refs/heads/master.zip"
   
   filePath <- tempfile("shinyapp", fileext = ".zip")
   fileDir  <- tempfile("shinyapp")  
@@ -11,7 +11,7 @@ run_app <- function(app = "kmeans"){
   
   try(utils::unzip(filePath, exdir = fileDir))
 
-  fp <- file.path(fileDir, "shiny-apps-edu-master", app)
+  fp <- file.path(fileDir, "shiny-apps-educational-master", app)
   
   shiny::runApp(fp)
   


### PR DESCRIPTION
## Summary

- Fix the local run instructions in `README.md`.
- Update the repository name from `shiny-apps-edu` to `shiny-apps-educational` where needed.
- Keep `run_app.R` pointing to the current repository archive and extracted folder.

## Notes

This PR is intentionally small and covers only the first cleanup item from the app review.