### PR TITLE
Fix app labels and README typos

### DIFF
--- a/bias-variance/readme.md
+++ b/bias-variance/readme.md
@@ -1,4 +1,4 @@
-Inspiration y resources:
+Inspiration and resources:
 
 - MLU [Bias Variance tradeoff](https://mlu-explain.github.io/bias-variance/) by Jared Wilber & Brent Werness.
 - [Understanding the Bias-Variance Tradeoff](https://scott.fortmann-roe.com/docs/BiasVariance.html).

--- a/binary-predictions-metrics/app.R
+++ b/binary-predictions-metrics/app.R
@@ -48,7 +48,7 @@ ui <- page_fillable(
   layout_sidebar(
     fillable = TRUE,
     sidebar = sidebar(
-      title = "Binary predicctions",
+      title = "Binary predictions",
       withMathJax(),
       selectInput("variable", tags$small("Variable"), choices = names(credit_data)[-1]),
       checkboxInput("logscale", tags$small("Log-scale on \\(x\\)-axis")),

--- a/decision-tree/readme.md
+++ b/decision-tree/readme.md
@@ -1,4 +1,4 @@
-Inspiration y resources:
+Inspiration and resources:
  - http://www.r2d3.us/visual-intro-to-machine-learning-part-1/
  - https://mlu-explain.github.io/decision-tree/
 

--- a/kmeans-images/readme.md
+++ b/kmeans-images/readme.md
@@ -1,7 +1,7 @@
-In evey image each pixel have a color and every color have an rgb representation 
-(a 3-coordinates point), so we can group the colors into clusters and see what happens.
-The pixel have a position too so a pixel can be represented as a 5 tuple of values.
-The idea behind this app is taken from [dsparks' kmeans palette](https://gist.github.com/dsparks/3980277). I just add some features like 3d scatterplot and migrate the code to a shiny app.
+Every image is made of pixels. Each pixel has a color, and every color has an RGB representation 
+(a 3-coordinate point), so we can group colors into clusters and see what happens.
+A pixel also has a position, so it can be represented as a 5-tuple of values.
+The idea behind this app is taken from [dsparks' kmeans palette](https://gist.github.com/dsparks/3980277). I added features like a 3D scatterplot and migrated the code to a Shiny app.
 
 App made by [@jbkunst](https://twitter.com/jbkunst) with ❤️ and for fun with #rstats. Code 
 [here](https://github.com/jbkunst/shiny-apps-educational).

--- a/logistic-regression/app.R
+++ b/logistic-regression/app.R
@@ -6,7 +6,6 @@ library(scales)
 library(markdown)
 library(broom)
 library(metR)
-library(scales)
 library(patchwork)
 library(geomtextpath) # remotes::install_github("AllanCameron/geomtextpath")
 library(risk3r)       # remotes::install_github("jbkunst/risk3r", force = TRUE)
@@ -65,7 +64,7 @@ ui <- page_fillable(
       ),
       sliderInput(
         "n",
-        tags$small("Number of observartions"),
+        tags$small("Number of observations"),
         min = 100,
         max = 1000,
         step = 100,
@@ -78,7 +77,7 @@ ui <- page_fillable(
       ),
       checkboxInput(
         "show_model_field", 
-        tags$small("Show model predicctions"),
+        tags$small("Show model predictions"),
         value = TRUE
       ),
       tags$small(htmltools::includeMarkdown("readme.md"))

--- a/lorenz-attractor/readme.md
+++ b/lorenz-attractor/readme.md
@@ -1,20 +1,20 @@
 The **Lorenz Attractor** is a set of chaotic solutions to a system of differential equations originally derived by Edward Lorenz in 1963 to model atmospheric convection. It serves as a classic example of deterministic chaos, where small differences in initial conditions can lead to vastly different outcomes.
 
-The Equations of the system is defined by three differential equations:
+The equations of the system are defined by three differential equations:
 
 $$\frac{{dx}}{{dt}} = \sigma (y - x),$$
 $$\frac{{dy}}{{dt}} = x (\rho - z) - y,$$
 $$\frac{{dz}}{{dt}} = x y - \beta z.$$
 
-Key Features are:
+Key features:
 - **Chaotic behavior:** Sensitive dependence on initial conditions.
 - **Fractal structure:** Exhibits a non-integer dimension.
 - **Aesthetic patterns:** Produces a "butterfly-shaped" trajectory.
 
-Some Applications:
+Some applications:
 - Meteorology and climate modeling.
 - Chaos theory and nonlinear dynamics.
 - Visualization of complex systems.
 
-App made by [@jbkunst](https://twitter.com/jbkunst) with ❤️ and for fun with #rstat and shiny assistant. Code 
+App made by [@jbkunst](https://twitter.com/jbkunst) with ❤️ and for fun with #rstats and Shiny assistant. Code 
 [here](https://github.com/jbkunst/shiny-apps-educational).


### PR DESCRIPTION
## Summary

- Fix visible typos in app labels for logistic regression and binary predictions.
- Remove a duplicated `library(scales)` import in `logistic-regression/app.R`.
- Clean small README typos/copy in `bias-variance`, `decision-tree`, `kmeans-images`, and `lorenz-attractor`.

## Notes

This PR only covers the second cleanup item from the review: simple visible text and typo fixes. It avoids behavior changes and larger refactors.