### PR TITLE
Align classification metric orientation

### DIFF
--- a/decision-tree/app.R
+++ b/decision-tree/app.R
@@ -166,7 +166,7 @@ server <- function(input, output, session) {
     
     aucroc <- Metrics::auc(
       actual = as.numeric(dxy$response),
-      predicted = dxy$prediction
+      predicted = 1 - dxy$prediction
     )
     
     ggplot(droc) +

--- a/logistic-regression/app.R
+++ b/logistic-regression/app.R
@@ -241,10 +241,10 @@ server <- function(input, output, session) {
     
     ksmod <- risk3r::ks(
       actual = as.numeric(dxy$response),
-      predicted = 1 - dxy$prediction
+      predicted = dxy$prediction
     )
     
-    ggplot(dxy, aes(1 - prediction, group = response, fill = response, color = response, label = response)) +
+    ggplot(dxy, aes(prediction, group = response, fill = response, color = response, label = response)) +
       geom_density(alpha = 0.1, linewidth = 2) +
       
       scale_color_manual(name = NULL, values = c(muted("red", 35), muted("blue", 35))) +


### PR DESCRIPTION
## Summary

- Align Decision Tree AUC with the ROC/KS score orientation already used in the app.
- Align Logistic Regression KS/density with the ROC/AUC score orientation already used in the app.

## Why this PR

The apps were mixing two score orientations: `prediction` in one metric and `1 - prediction` in another. That can make the visual ROC/KS panels and the reported AUC/KS numbers disagree conceptually. This PR keeps one orientation per app so the plots and summary metrics are easier to interpret.

## Scope

Small behavior fix only. No UI redesign, no refactor, no dependency changes.