### PR TITLE
Clarify binary predictions draft status

### DIFF
--- a/binary-predictions-metrics/app.R
+++ b/binary-predictions-metrics/app.R
@@ -58,14 +58,6 @@ ui <- page_fillable(
       width = 1/2,
       height = "60%",
       card(highchartOutput("hcpoints"))
-      ),
-    layout_column_wrap(
-      width = 1/4,
-      height = "40%",
-      card(
-        # card_header(uiOutput("iter")),
-        # card_body(plotOutput("iter_plot"))
-        )
       )
     )
   )

--- a/deploy_apps.R
+++ b/deploy_apps.R
@@ -12,6 +12,7 @@ apps_valid <- map(apps, dir) |>
 
 apps <- apps[apps_valid]
 
+# This app is still a draft and is intentionally excluded from shinyapps.io deploys.
 apps <- setdiff(apps, c("binary-predictions-metrics"))
 
 if(FALSE){


### PR DESCRIPTION
## Summary

- Add an explicit comment explaining why `binary-predictions-metrics` is excluded from `deploy_apps.R`.
- Remove an empty card/layout block from the app UI.

## Why this PR

The app currently looks like a draft: it is excluded from deploys and has an empty panel in the UI. This PR makes that status explicit and removes the empty visual area, without trying to redesign or finish the app.

## Scope

Small cleanup only. The app behavior is otherwise unchanged.