### PR TITLE
Fix K-means image sampling

### DIFF
--- a/kmeans-images/app.R
+++ b/kmeans-images/app.R
@@ -27,9 +27,11 @@ sidebar <- purrr::partial(bslib::sidebar, width = 300)
 card <- purrr::partial(bslib::card, full_screen = TRUE)
  
 # app options -------------------------------------------------------------
+img_files <- dir("www/imgs/", full.names = TRUE)
+
 img_choices <- setNames(
-  dir("www/imgs/", full.names = TRUE),
-  str_to_title(gsub("\\.jpg$|\\.jpeg$|", "", dir("www/imgs/")))
+  img_files,
+  str_to_title(tools::file_path_sans_ext(basename(img_files)))
 )
 
 # ui ----------------------------------------------------------------------
@@ -240,7 +242,7 @@ server <- function(input, output, session) {
     set.seed(123)
     
     daux <- df_image |> 
-      sample_n(1000) |>
+      slice_sample(n = min(1000, nrow(df_image))) |>
       mutate(across(c(r, g, b), function(x) round(x, 2))) |>
       mutate(label = sprintf("rgb (%s, %s, %s)", r, g, b))
     
@@ -316,8 +318,8 @@ server <- function(input, output, session) {
     set.seed(123)
     
     daux <- df_image_kmeans |> 
-      sample_n(1000) |> 
-      mutate(across(c(r, g, b), function(x) round(x, 2))) |> 
+      slice_sample(n = min(1000, nrow(df_image_kmeans))) |>
+      mutate(across(c(r, g, b), function(x) round(x, 2))) |>
       mutate(across(c(r_app, g_app, b_app), function(x) round(x, 2))) |> 
       mutate(
         label = sprintf("rgb (%s, %s, %s)", r, g, b),


### PR DESCRIPTION
## Summary

- Build image labels with `tools::file_path_sans_ext()` instead of a fragile regex.
- Make the 3D pixel samples safe when an image has fewer than 1000 pixels.

## Notes

I found one more candidate in `binary-predictions-metrics/app.R`: `sample_n(200)` can fail if a status group has fewer than 200 rows after filtering. I did not include it here because the write was blocked by the integration, so this PR stays focused on `kmeans-images`.

## Scope

Small bug fix only. No UI redesign.