### PR TITLE
Use zero-padding card wrapper across apps

### DIFF
--- a/app-template/app.R
+++ b/app-template/app.R
@@ -7,7 +7,7 @@ apptheme <- bs_theme()
 
 sidebar <- purrr::partial(bslib::sidebar, width = 300)
 
-card <- purrr::partial(bslib::card, full_screen = TRUE)
+card <- purrr::partial(bslib::card, full_screen = TRUE, wrapper = purrr::partial(bslib::card_body, padding = 0))
 
 # ui ----------------------------------------------------------------------
 ui <- page_fillable(

--- a/arma-process/app.R
+++ b/arma-process/app.R
@@ -9,7 +9,7 @@ apptheme <- bs_theme()
 
 sidebar <- purrr::partial(bslib::sidebar, width = 300)
 
-card <- purrr::partial(bslib::card, full_screen = TRUE)
+card <- purrr::partial(bslib::card, full_screen = TRUE, wrapper = purrr::partial(bslib::card_body, padding = 0))
 
 options(
   highcharter.theme = hc_theme(

--- a/binary-predictions-metrics/app.R
+++ b/binary-predictions-metrics/app.R
@@ -13,7 +13,7 @@ apptheme <- bs_theme()
 
 sidebar <- purrr::partial(bslib::sidebar, width = 300)
 
-card <- purrr::partial(bslib::card, full_screen = TRUE)
+card <- purrr::partial(bslib::card, full_screen = TRUE, wrapper = purrr::partial(bslib::card_body, padding = 0))
 
 options(
   highcharter.theme = hc_theme(

--- a/decision-tree/app.R
+++ b/decision-tree/app.R
@@ -16,7 +16,7 @@ apptheme <- bs_theme()
 
 sidebar <- purrr::partial(bslib::sidebar, width = 300)
 
-card <- purrr::partial(bslib::card, full_screen = TRUE)
+card <- purrr::partial(bslib::card, full_screen = TRUE, wrapper = purrr::partial(bslib::card_body, padding = 0))
 
 thematic::thematic_shiny(font = "auto")
 

--- a/dimensionality-reduction/app.R
+++ b/dimensionality-reduction/app.R
@@ -17,7 +17,7 @@ thematic::thematic_shiny(font = "auto")
 apptheme <- bs_theme()
 
 sidebar <- purrr::partial(bslib::sidebar, width = 300)
-card <- purrr::partial(bslib::card, full_screen = TRUE)
+card <- purrr::partial(bslib::card, full_screen = TRUE, wrapper = purrr::partial(bslib::card_body, padding = 0))
 
 # app options -------------------------------------------------------------
 n_choices <- c("100", "200", "500", "700", "1000")
@@ -938,7 +938,6 @@ server <- function(input, output, session) {
       )
 
       incProgress(0.2, detail = "PCA")
-
       projections <- list()
       projections$pca <- run_pca(generated$x)
 

--- a/kmeans-images/app.R
+++ b/kmeans-images/app.R
@@ -20,7 +20,7 @@ apptheme <- bs_theme()
 
 sidebar <- purrr::partial(bslib::sidebar, width = 300)
 
-card <- purrr::partial(bslib::card, full_screen = TRUE)
+card <- purrr::partial(bslib::card, full_screen = TRUE, wrapper = purrr::partial(bslib::card_body, padding = 0))
  
 # app options -------------------------------------------------------------
 img_files <- dir("www/imgs/", full.names = TRUE)

--- a/kmeans-images/app_no_sync.R
+++ b/kmeans-images/app_no_sync.R
@@ -24,7 +24,7 @@ apptheme <- bs_theme()
 
 sidebar <- purrr::partial(bslib::sidebar, width = 300)
 
-card <- purrr::partial(bslib::card, full_screen = TRUE)
+card <- purrr::partial(bslib::card, full_screen = TRUE, wrapper = purrr::partial(bslib::card_body, padding = 0))
  
 # app options -------------------------------------------------------------
 img_choices <- setNames(

--- a/kmeans/app.R
+++ b/kmeans/app.R
@@ -15,7 +15,7 @@ thematic::thematic_shiny(font = "auto")
 apptheme <- bs_theme()
 
 sidebar <- purrr::partial(bslib::sidebar, width = 300)
-card <- purrr::partial(bslib::card, full_screen = TRUE)
+card <- purrr::partial(bslib::card, full_screen = TRUE, wrapper = purrr::partial(bslib::card_body, padding = 0))
 
 primary_color <- unname(bs_get_variables(apptheme, c("primary")))
 

--- a/kmeans/app_ggplot2.R
+++ b/kmeans/app_ggplot2.R
@@ -20,7 +20,7 @@ apptheme <- bs_theme()
 
 sidebar <- purrr::partial(bslib::sidebar, width = 300)
 
-card <- purrr::partial(bslib::card, full_screen = TRUE)
+card <- purrr::partial(bslib::card, full_screen = TRUE, wrapper = purrr::partial(bslib::card_body, padding = 0))
 
 primary_color <- unname(bs_get_variables(apptheme, c("primary")))
 

--- a/logistic-regression/app.R
+++ b/logistic-regression/app.R
@@ -14,7 +14,7 @@ apptheme <- bs_theme()
 
 sidebar <- purrr::partial(bslib::sidebar, width = 300)
 
-card <- purrr::partial(bslib::card)
+card <- purrr::partial(bslib::card, full_screen = TRUE, wrapper = purrr::partial(bslib::card_body, padding = 0))
 
 thematic::thematic_shiny(font = "auto")
 

--- a/lorenz-attractor/app.R
+++ b/lorenz-attractor/app.R
@@ -12,7 +12,7 @@ apptheme <- bs_theme()
 
 sidebar <- purrr::partial(bslib::sidebar, width = 300)
 
-card <- purrr::partial(bslib::card, full_screen = TRUE)
+card <- purrr::partial(bslib::card, full_screen = TRUE, wrapper = purrr::partial(bslib::card_body, padding = 0))
 
 thematic::thematic_shiny(font = "auto")
 
@@ -20,7 +20,7 @@ theme_set(theme_minimal() + theme(legend.position = "none"))
 
 # app options -------------------------------------------------------------
 generate_lorenz <- function(sigma = 10, rho = 28, beta = 8/3, 
-                            start = c(1, 1, 1), n = 1000, dt = 0.01) {
+                             start = c(1, 1, 1), n = 1000, dt = 0.01) {
   x <- y <- z <- numeric(n)
   x[1] <- start[1]
   y[1] <- start[2]

--- a/network-structures/app.R
+++ b/network-structures/app.R
@@ -12,7 +12,7 @@ thematic::thematic_shiny(font = "auto")
 apptheme <- bs_theme()
 
 sidebar <- purrr::partial(bslib::sidebar, width = 300)
-card <- purrr::partial(bslib::card, full_screen = TRUE)
+card <- purrr::partial(bslib::card, full_screen = TRUE, wrapper = purrr::partial(bslib::card_body, padding = 0))
 
 # app options -------------------------------------------------------------
 N_MAX <- 1000

--- a/roc-curve/app.R
+++ b/roc-curve/app.R
@@ -8,7 +8,7 @@ library(tibble)
 apptheme <- bs_theme(primary = "#007BC2")
 
 sidebar <- purrr::partial(bslib::sidebar, width = 300)
-card <- purrr::partial(bslib::card, full_screen = TRUE)
+card <- purrr::partial(bslib::card, full_screen = TRUE, wrapper = purrr::partial(bslib::card_body, padding = 0))
 
 # app options -------------------------------------------------------------
 mean_negative_choices <- c("-4", "-3", "-2", "-1", "-0.5", "0")
@@ -162,7 +162,6 @@ server <- function(input, output, session) {
         lapply(names(class_palette), function(observed) {
           scores <- data$score[data$observed == observed]
           estimate <- density(scores, from = min(score_grid), to = max(score_grid), n = 512)
-
           tibble(
             score = score_grid,
             observed = factor(observed, levels = names(class_palette)),

--- a/roc-curve/app_simulated.R
+++ b/roc-curve/app_simulated.R
@@ -8,7 +8,7 @@ library(tibble)
 apptheme <- bs_theme(primary = "#007BC2")
 
 sidebar <- purrr::partial(bslib::sidebar, width = 300)
-card <- purrr::partial(bslib::card, full_screen = TRUE)
+card <- purrr::partial(bslib::card, full_screen = TRUE, wrapper = purrr::partial(bslib::card_body, padding = 0))
 
 # app options -------------------------------------------------------------
 mean_negative_choices <- c("-4", "-3", "-2", "-1", "-0.5", "0")
@@ -127,6 +127,7 @@ server <- function(input, output, session) {
       )
     )
   })
+
   density_data <- reactive({
     data <- data_sample()
     threshold <- as.numeric(input$threshold)
@@ -408,6 +409,7 @@ server <- function(input, output, session) {
     },
     ignoreInit = TRUE
   )
+
   observeEvent(input$threshold, {
     density <- density_data()
     y_max <- max(density$density)

--- a/roc-curve/app_theoretical.R
+++ b/roc-curve/app_theoretical.R
@@ -8,7 +8,7 @@ library(tibble)
 apptheme <- bs_theme(primary = "#007BC2")
 
 sidebar <- purrr::partial(bslib::sidebar, width = 300)
-card <- purrr::partial(bslib::card, full_screen = TRUE)
+card <- purrr::partial(bslib::card, full_screen = TRUE, wrapper = purrr::partial(bslib::card_body, padding = 0))
 
 # app options -------------------------------------------------------------
 mean_negative_choices <- c("-4", "-3", "-2", "-1", "-0.5", "0")
@@ -406,6 +406,7 @@ server <- function(input, output, session) {
     },
     ignoreInit = TRUE
   )
+
   observeEvent(input$threshold, {
     density <- density_data()
     y_max <- max(density$density)

--- a/underfitting-overfitting/app.R
+++ b/underfitting-overfitting/app.R
@@ -11,7 +11,7 @@ library(shinyWidgets)
 apptheme <- bs_theme()
 
 sidebar <- purrr::partial(bslib::sidebar, width = 300)
-card <- purrr::partial(bslib::card, full_screen = TRUE)
+card <- purrr::partial(bslib::card, full_screen = TRUE, wrapper = purrr::partial(bslib::card_body, padding = 0))
 
 options(
   highcharter.theme = hc_theme(


### PR DESCRIPTION
Standardizes the shared `card` helper across the app collection, including `app-template`, so direct card content is wrapped in `bslib::card_body(..., padding = 0)` while keeping full-screen support.

Changed 16 source files. Generated `docs/`/Shinylive output is intentionally not edited by hand.

Build note: the full site rebuild was not run from this environment because there is no PR workflow configured, and `R/build_site.R` is configured to commit and push generated output to `master`.