### PR TITLE
Show successful Shinylive exports in build logs

### DIFF
--- a/R/build_site.R
+++ b/R/build_site.R
@@ -71,6 +71,7 @@ shinylive_export_catch <- function(meta) {
         stop("Shinylive export completed, but index.html is missing.", call. = FALSE)
       }
 
+      cli::cli_alert_success("Exported {meta$app}")
       list(ok = TRUE, message = "Shinylive export completed.")
     },
     error = function(e) list(ok = FALSE, message = conditionMessage(e))


### PR DESCRIPTION
Adds one `cli::cli_alert_success()` after each successful Shinylive export so GitHub Actions logs clearly show which apps completed. No other build behavior changes.