### PR TITLE
Install all custom Shinylive packages from tags

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -47,6 +47,8 @@ jobs:
             any::webshot2
             any::yaml
             github::jbkunst/klassets@v0.1.2
+            github::jbkunst/celavi@v0.1.2
+            github::jbkunst/risk3r@v0.1.2
 
       - name: Cache Shinylive assets and packages
         uses: actions/cache@v4


### PR DESCRIPTION
Adds the two remaining custom packages to the Pages build so the Shinylive export has the full tagged dependency chain available explicitly:

- `klassets@v0.1.2`
- `celavi@v0.1.2`
- `risk3r@v0.1.2`

Checked current apps:
- `kmeans` uses `klassets`.
- `decision-tree` uses `risk3r` and `klassets`.
- `logistic-regression` uses `risk3r` and `klassets`.
- `risk3r` imports `celavi`, so `celavi` is required transitively.
- `roc-curve` does not use these custom packages directly.