### PR TITLE
Authenticate Shinylive GitHub release checks

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -16,6 +16,8 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ github.token }}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Adds `GITHUB_PAT: ${{ github.token }}` to the Pages workflow so `gh::gh()` calls made during Shinylive export are authenticated. This avoids the anonymous GitHub API rate limit that caused the misleading `Can't find GitHub release` error for `klassets@v0.1.2`.